### PR TITLE
Add setBelow property for setting tooltip position below target

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ class App extends React.Component {
 | springConfig | `Object` | {tension: 100, friction: 7} | Configuration of spring animation. Attributes tension and friction control the behavior of the spring bumper effect.
 | opacityChangeDuration | `number` | 200 | Duration of opacity change of the overlay, during both appearance and dispearance.
 | buttonComponentExpandRatio | `number` | 1.0 | Ratio of button component expansion after tooltip poped up.
+| setBlow | `Boolean` | false | Sets the default position of the tooltip to appear below the intended target.
 
 ## Methods:
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ class App extends React.Component {
 | springConfig | `Object` | {tension: 100, friction: 7} | Configuration of spring animation. Attributes tension and friction control the behavior of the spring bumper effect.
 | opacityChangeDuration | `number` | 200 | Duration of opacity change of the overlay, during both appearance and dispearance.
 | buttonComponentExpandRatio | `number` | 1.0 | Ratio of button component expansion after tooltip poped up.
-| setBlow | `Boolean` | false | Sets the default position of the tooltip to appear below the intended target.
+| setBelow | `Boolean` | false | Sets the default position of the tooltip to appear below the intended target.
 
 ## Methods:
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ class PopoverTooltip extends React.Component {
       opacity: new Animated.Value(0),
       tooltip_container_scale: new Animated.Value(0),
       button_component_container_scale: 1,
-      tooptip_triangle_down: true,
+      tooptip_triangle_down: !props.setBelow,
       tooltip_triangle_left_margin: 0,
       will_popup: false
     };
@@ -125,8 +125,8 @@ class PopoverTooltip extends React.Component {
                     if (this.state.will_popup && tooltip_container_width > 0 && tooltip_container_height > 0) {
                       this._component_wrapper.measure((x, y, width, height, pageX, pageY) => {
                         let tooltip_container_x_final=pageX+tooltip_container_width+(width-tooltip_container_width)/2>window.width? window.width-tooltip_container_width : pageX+(width-tooltip_container_width)/2;
-                        let tooltip_container_y_final=pageY-tooltip_container_height-20;
-                        let tooltip_triangle_down=true;
+	                    let tooltip_container_y_final = this.state.tooptip_triangle_down ? pageY - tooltip_container_height - 20 : pageY + tooltip_container_height - 20;
+                        let tooltip_triangle_down = this.state.tooptip_triangle_down;
                         if (pageY-tooltip_container_height-20<0) {
                           tooltip_container_y_final=pageY+height+20;
                           tooltip_triangle_down=false;
@@ -269,6 +269,7 @@ PopoverTooltip.propTypes = {
   labelContainerStyle: React.PropTypes.object,
   labelSeparatorColor: React.PropTypes.string,
   labelStyle: React.PropTypes.object,
+  setBelow: React.PropTypes.bool,
   animationType: React.PropTypes.oneOf([
     'timing',
     'spring'
@@ -280,6 +281,7 @@ PopoverTooltip.defaultProps = {
   buttonComponentExpandRatio: 1.0,
   labelSeparatorColor: '#E1E1E1',
   onRequestClose: () => {},
+  setBelow: false,
   delayLongPress: 100
 };
 


### PR DESCRIPTION
Added setBlow property to allow for defaulting the position of the tooltip to appear below the intended target. README has been updated to reflect the change