### PR TITLE
Fix for ToolTip Going Off The Screen when Near Bottom

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,10 @@ class PopoverTooltip extends React.Component {
                           tooltip_container_y_final=pageY+height+20;
                           tooltip_triangle_down=false;
                         }
+                        if (pageY + tooltip_container_height + 80 > window.height) {
+                        	tooltip_container_y_final = pageY - tooltip_container_height - 20;
+                        	tooltip_triangle_down = true
+                        }
                         let tooltip_container_x = this.state.tooltip_container_scale.interpolate({
                           inputRange: [0, 1],
                           outputRange: [tooltip_container_x_final, tooltip_container_x_final]


### PR DESCRIPTION
Fix for forcing Tooltip to appear above target when near bottom of screen. Prevents ToolTip from going off the screen.