### PR TITLE
Fix triangle wrong color bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -258,7 +258,7 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
     const labelContainerStyle = this.props.labelContainerStyle;
     const borderStyle =
       labelContainerStyle && labelContainerStyle.backgroundColor
-        ? { borderTopColor: labelContainerStyle.backgroundColor }
+        ? this.props.setBelow ? { borderBottomColor: labelContainerStyle.backgroundColor } : { borderTopColor: labelContainerStyle.backgroundColor }
         : null;
     let triangleDown = null;
     let triangleUp = null;


### PR DESCRIPTION
If setBelow={true} and set backgroundColor to labelContainer was bug with triangle color (was white), I fixed it