### PR TITLE
Use Modal's onDismiss to prevent Alert bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-popover-tooltip",
-  "version": "1.1.1",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,7 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
     triangleOffset: 0,
   };
   wrapperComponent: ?TouchableOpacity;
+  callOnDismiss: ?(() => void) = null;
 
   constructor(props: Props) {
     super(props);
@@ -150,8 +151,12 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
   }
 
   onPressItem = (userCallback: () => void) => {
+    if (this.state.isModalOpen) {
+      this.callOnDismiss = userCallback;
+    } else {
+      userCallback();
+    }
     this.toggle();
-    userCallback();
   }
 
   onInnerContainerLayout = (
@@ -304,6 +309,7 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
         <Modal
           visible={this.state.isModalOpen}
           onRequestClose={this.props.onRequestClose}
+          onDismiss={this.onDismiss}
           transparent
         >
           <Animated.View style={[
@@ -436,6 +442,13 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
       this.hideModal();
     } else {
       this.openModal();
+    }
+  }
+
+  onDismiss = () => {
+    if (this.callOnDismiss) {
+      this.callOnDismiss();
+      this.callOnDismiss = null;
     }
   }
 


### PR DESCRIPTION
There is an annoying issue in React Native where if you call an `Alert` right as a `Modal` is being closed, it can crash the UI thread: https://github.com/facebook/react-native/issues/10471

The solution, which is available in RN 0.50, is a new callback property on `Modal` called `onDismiss`. Calling `Alert` from within this callback is safe.

This PR makes it so this component calls the user callback from within `onDismiss`. It should have no impact if the user is not calling `Alert`.